### PR TITLE
Use secp521r1 curve instead of sect571k1

### DIFF
--- a/libs/fscp/fscp.txt
+++ b/libs/fscp/fscp.txt
@@ -472,7 +472,7 @@ Abstract
    - 0x01: ECDHE-RSA-AES128-GCM-SHA256
    - 0x02: ECDHE-RSA-AES256-GCM-SHA384
 
-   The curve used for ECDHE is SECT571K1.
+   The curve used for ECDHE is SECP521R1.
 
 3.2. Signature algorithms
 

--- a/libs/fscp/include/fscp/constants.hpp
+++ b/libs/fscp/include/fscp/constants.hpp
@@ -359,7 +359,7 @@ namespace fscp
 					throw std::runtime_error("Unsupported cipher suite value: " + boost::lexical_cast<std::string>(static_cast<int>(value())));
 				}
 
-				return NID_sect571k1;
+				return NID_secp521r1;
 			}
 
 			/**


### PR DESCRIPTION
It's in every ssl libs
(http://en.wikipedia.org/wiki/Comparison_of_TLS_implementations)
and for openssl it's in every distribution
(for exemple fedora 20 only has secp521r1, secp384r1, prime256v1)

Signed-off-by: Etienne CHAMPETIER etienne.champetier@free.fr
