### PR TITLE
Fixed compilation errors under Archlinux and possibly other platforms

### DIFF
--- a/libs/asiotap/include/asiotap/types/endpoint.hpp
+++ b/libs/asiotap/include/asiotap/types/endpoint.hpp
@@ -350,6 +350,9 @@ namespace asiotap
 	 */
 	std::istream& operator>>(std::istream& is, endpoint& value);
 
+// Note: this operator is defined in boost variant as of version 1.58. Keeping it around will
+// introduce overload resolution ambiguity.
+#if BOOST_VERSION < 105800
 	/**
 	 * \brief Compare two endpoints.
 	 * \param lhs The left argument.
@@ -360,6 +363,7 @@ namespace asiotap
 	{
 		return !(lhs == rhs);
 	}
+#endif
 
 	/**
 	 * \brief Get an endpoint with a default port.

--- a/libs/freelan/src/curl.cpp
+++ b/libs/freelan/src/curl.cpp
@@ -146,7 +146,7 @@ namespace freelan
 
 	void curl::set_proxy(const asiotap::endpoint& proxy)
 	{
-		if (proxy != asiotap::hostname_endpoint::null())
+		if (proxy != asiotap::endpoint(asiotap::hostname_endpoint::null()))
 		{
 			set_option(CURLOPT_PROXY, static_cast<const void*>(boost::lexical_cast<std::string>(proxy).c_str()));
 		}


### PR DESCRIPTION
* Removed redundant inequality comparison operator from asiotap::endpoint. This
  operator introduces overload resolution ambiguity and on top of that it is
  already implemented by boost::variant;
* Fixed a compilation issue triggered by comparing a boost::variant to a foreign
  type.

Possibly fixes #68.