### PR TITLE
3rd party: update openssl and curl; add flags to fix the build on recent osx (10.10.5)

### DIFF
--- a/.party
+++ b/.party
@@ -70,7 +70,7 @@ Attendee('boost').get_build('msvc-x64').commands = [
 
 # OpenSSL
 Attendee('openssl', filter=~f('linux'))
-Attendee('openssl').add_source('http://www.openssl.org/source/openssl-1.0.2a.tar.gz')
+Attendee('openssl').add_source('http://www.openssl.org/source/openssl-1.0.2d.tar.gz')
 
 Attendee('openssl').add_build('osx', environment='system', filter='darwin')
 Attendee('openssl').get_build('osx').commands = [
@@ -122,14 +122,14 @@ Attendee('openssl').get_build('msvc-x64-debug').commands = [
 
 # cURL
 Attendee('curl', filter=~f('linux'))
-Attendee('curl').add_source('http://curl.askapache.com/download/curl-7.41.0.zip', filter='windows', mimetype='application/zip')
-Attendee('curl').add_source('http://curl.askapache.com/download/curl-7.41.0.tar.bz2', filter=~f('windows'), mimetype='application/x-bzip2')
+Attendee('curl').add_source('http://curl.askapache.com/download/curl-7.45.0.zip', filter='windows', mimetype='application/zip')
+Attendee('curl').add_source('http://curl.askapache.com/download/curl-7.45.0.tar.bz2', filter=~f('windows'), mimetype='application/x-bzip2')
 
 Attendee('curl').depends_on('openssl')
 
 Attendee('curl').add_build('osx', environment='system', filter='darwin')
 Attendee('curl').get_build('osx').commands = [
-     'sh configure --enable-static -disable-shared --without-darwinssl --with-ssl={{prefix}} --prefix={{prefix}}',
+     'sh configure --enable-static -disable-shared --disable-ldap --without-libidn --without-darwinssl --with-ssl={{prefix}} --prefix={{prefix}}',
      'make',
      'make install',
 ]


### PR DESCRIPTION
btw, openssl 1.0.2a is not available for download anymore
also without "--disable-ldap --without-libidn" I had different linking errors