### PR TITLE
SCons build warning when no C++ compiler

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -23,7 +23,7 @@ This will build everything inside `third-party`. Once that is done, you can proc
 
 To install the required dependencies on Debian Linux (Or Ubuntu), type the following command:
 
-> sudo apt-get install scons python libssl-dev libcurl4-openssl-dev libboost-system-dev libboost-thread-dev libboost-program-options-dev libboost-filesystem-dev libboost-iostreams-dev
+> sudo apt-get install scons python libssl-dev libcurl4-openssl-dev libboost-system-dev libboost-thread-dev libboost-program-options-dev libboost-filesystem-dev libboost-iostreams-dev g++
 
 Building FreeLAN
 ----------------

--- a/BUILD.md
+++ b/BUILD.md
@@ -23,7 +23,7 @@ This will build everything inside `third-party`. Once that is done, you can proc
 
 To install the required dependencies on Debian Linux (Or Ubuntu), type the following command:
 
-> sudo apt-get install scons python libssl-dev libcurl4-openssl-dev libboost-system-dev libboost-thread-dev libboost-program-options-dev libboost-filesystem-dev libboost-iostreams-dev g++
+> sudo apt-get install scons python libssl-dev libcurl4-openssl-dev libboost-system-dev libboost-thread-dev libboost-program-options-dev libboost-filesystem-dev libboost-iostreams-dev build-essential
 
 Building FreeLAN
 ----------------

--- a/SConstruct
+++ b/SConstruct
@@ -83,7 +83,9 @@ class FreelanEnvironment(Environment):
 
         if self['CXX'] is None:
             raise SCons.Errors.BuildError(
-                errstr="CXX environment variable not set. Are you missing a C++ compiler?")
+                errstr=(
+                    "Failed to detect C++ compiler : CXX environment variable not set."
+                    "\nIs g++ or clang++ available in your PATH ?"))
         else:
             if os.path.basename(self['CXX']) == 'clang++':
                 self.Append(CXXFLAGS=['-Qunused-arguments'])

--- a/SConstruct
+++ b/SConstruct
@@ -85,7 +85,9 @@ class FreelanEnvironment(Environment):
             raise SCons.Errors.BuildError(
                 errstr=(
                     "Failed to detect C++ compiler : CXX environment variable not set."
-                    "\nIs g++ or clang++ available in your PATH ?"))
+                    "\nIs g++ or clang++ available in your PATH ?"
+                    "\nIf you have no idea what this is about,"
+                    "\ntry installing the 'build-essential' package"))
         else:
             if os.path.basename(self['CXX']) == 'clang++':
                 self.Append(CXXFLAGS=['-Qunused-arguments'])

--- a/SConstruct
+++ b/SConstruct
@@ -6,6 +6,7 @@ Works on all UNIX-like operating systems.
 
 import os
 import sys
+import SCons.Errors
 
 from fnmatch import fnmatch
 
@@ -80,11 +81,15 @@ class FreelanEnvironment(Environment):
             self.install_prefix = self.prefix
             self.bin_install_prefix = self.bin_prefix
 
-        if os.path.basename(self['CXX']) == 'clang++':
-            self.Append(CXXFLAGS=['-Qunused-arguments'])
-            self.Append(CXXFLAGS=['-fcolor-diagnostics'])
-        elif os.path.basename(self['CXX']).startswith('g++'):
-            self.Append(CXXFLAGS=['-Wno-missing-field-initializers'])
+        if self['CXX'] is None:
+          raise SCons.Errors.BuildError(
+            errstr="CXX environment variable not set. Are you missing a C++ compiler?");
+        else:
+          if os.path.basename(self['CXX']) == 'clang++':
+              self.Append(CXXFLAGS=['-Qunused-arguments'])
+              self.Append(CXXFLAGS=['-fcolor-diagnostics'])
+          elif os.path.basename(self['CXX']).startswith('g++'):
+              self.Append(CXXFLAGS=['-Wno-missing-field-initializers'])
 
         self.Append(CXXFLAGS=['--std=c++11'])
         self.Append(CXXFLAGS=['-Wall'])

--- a/SConstruct
+++ b/SConstruct
@@ -82,14 +82,14 @@ class FreelanEnvironment(Environment):
             self.bin_install_prefix = self.bin_prefix
 
         if self['CXX'] is None:
-          raise SCons.Errors.BuildError(
-            errstr="CXX environment variable not set. Are you missing a C++ compiler?");
+            raise SCons.Errors.BuildError(
+                errstr="CXX environment variable not set. Are you missing a C++ compiler?")
         else:
-          if os.path.basename(self['CXX']) == 'clang++':
-              self.Append(CXXFLAGS=['-Qunused-arguments'])
-              self.Append(CXXFLAGS=['-fcolor-diagnostics'])
-          elif os.path.basename(self['CXX']).startswith('g++'):
-              self.Append(CXXFLAGS=['-Wno-missing-field-initializers'])
+            if os.path.basename(self['CXX']) == 'clang++':
+                self.Append(CXXFLAGS=['-Qunused-arguments'])
+                self.Append(CXXFLAGS=['-fcolor-diagnostics'])
+            elif os.path.basename(self['CXX']).startswith('g++'):
+                self.Append(CXXFLAGS=['-Wno-missing-field-initializers'])
 
         self.Append(CXXFLAGS=['--std=c++11'])
         self.Append(CXXFLAGS=['-Wall'])


### PR DESCRIPTION
Following #116 ; Added an SCons build error if the CXX variable is unset (meaning no C++ compiler was detected).

Also added `g++` package to the list of Debian/Ubuntu build dependencies.

I don't know how to compile from source on other systems. Maybe `g++` should be added to the teapot dependencies as well ?