### PR TITLE
Fixes compilation with g++-7.

### DIFF
--- a/libs/asiotap/src/posix/posix_tap_adapter.cpp
+++ b/libs/asiotap/src/posix/posix_tap_adapter.cpp
@@ -206,6 +206,7 @@ namespace asiotap
 						{
 							result[name] = name;
 						}
+						break;
 					}
 					case tap_adapter_layer::ip:
 					{
@@ -213,6 +214,7 @@ namespace asiotap
 						{
 							result[name] = name;
 						}
+						break;
 					}
 				}
 			}

--- a/libs/netlinkplus/include/netlinkplus/endpoint.hpp
+++ b/libs/netlinkplus/include/netlinkplus/endpoint.hpp
@@ -44,6 +44,8 @@
 
 #pragma once
 
+#include <cstring>
+
 #include <boost/asio.hpp>
 
 #include <linux/netlink.h>
@@ -125,17 +127,17 @@ namespace netlinkplus
 
 			friend bool operator==(const netlink_endpoint& lhs, const netlink_endpoint& rhs)
 			{
-				return (lhs.m_sockaddr == rhs.m_sockaddr);
+				return (std::memcmp(&lhs.m_sockaddr, &rhs.m_sockaddr, sizeof(sockaddr_nl)) == 0);
 			}
 
 			friend bool operator!=(const netlink_endpoint& lhs, const netlink_endpoint& rhs)
 			{
-				return (lhs.m_sockaddr != rhs.m_sockaddr);
+				return (std::memcmp(&lhs.m_sockaddr, &rhs.m_sockaddr, sizeof(sockaddr_nl)) != 0);
 			}
 
 			friend bool operator<(const netlink_endpoint& lhs, const netlink_endpoint& rhs)
 			{
-				return (lhs.m_sockaddr < rhs.m_sockaddr);
+				return (std::memcmp(&lhs.m_sockaddr, &rhs.m_sockaddr, sizeof(sockaddr_nl)) < 0);
 			}
 
 		private:


### PR DESCRIPTION
Attempt to fix issue #131.

Use std::memcp to Instead of ==/!=/< operator on struct sockaddr_nl and fix a possible switch fall through.