### PR TITLE
Fixes for OSX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@
 /.bash_history
 /build/
 /install/
+/.sconf_temp/
+/config.log
 
 # Visual Studio
 *.suo

--- a/libs/fscp/src/server.cpp
+++ b/libs/fscp/src/server.cpp
@@ -53,7 +53,16 @@
 #include "session_message.hpp"
 #include "data_message.hpp"
 
+// Mac OSX version of Boost has shadowing warnings that fail the build.
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wshadow"
+#endif
 #include <boost/random.hpp>
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
+
 #include <boost/make_shared.hpp>
 #include <boost/ref.hpp>
 #include <boost/thread/future.hpp>


### PR DESCRIPTION
This PR fixes a compilation error on Mac OSX where the boost version contains a faulty version of Boost Random that has shadowing warnings.

It also updates the `.gitignore` file to include newly generated files.