### PR TITLE
Fixed support to contact both ipv4 and ipv6 hosts

### DIFF
--- a/libs/asiotap/include/asiotap/types/ip_endpoint.hpp
+++ b/libs/asiotap/include/asiotap/types/ip_endpoint.hpp
@@ -226,9 +226,12 @@ namespace asiotap
 	template <typename AddressType>
 	inline void async_resolve(const base_ip_endpoint<AddressType>& ep, typename base_ip_endpoint<AddressType>::resolver& resolver, typename base_ip_endpoint<AddressType>::resolver::protocol_type protocol, typename base_ip_endpoint<AddressType>::resolver::query::flags flags, const std::string& default_service, typename base_ip_endpoint<AddressType>::handler handler)
 	{
-		typename base_ip_endpoint<AddressType>::resolver::query query(protocol, ep.address().to_string(), ep.has_port() ? boost::lexical_cast<std::string>(ep.port()) : default_service, flags);
-
+		static_cast<void>(flags);
+		static_cast<void>(protocol);
+		typename base_ip_endpoint<AddressType>::resolver::query query(ep.address().to_string(), ep.has_port() ? boost::lexical_cast<std::string>(ep.port()) : default_service, boost::asio::ip::resolver_query_base::numeric_host);
+		
 		resolver.async_resolve(query, handler);
+		return;
 	}
 
 	/**

--- a/libs/asiotap/include/asiotap/types/ip_endpoint.hpp
+++ b/libs/asiotap/include/asiotap/types/ip_endpoint.hpp
@@ -226,12 +226,10 @@ namespace asiotap
 	template <typename AddressType>
 	inline void async_resolve(const base_ip_endpoint<AddressType>& ep, typename base_ip_endpoint<AddressType>::resolver& resolver, typename base_ip_endpoint<AddressType>::resolver::protocol_type protocol, typename base_ip_endpoint<AddressType>::resolver::query::flags flags, const std::string& default_service, typename base_ip_endpoint<AddressType>::handler handler)
 	{
-		static_cast<void>(flags);
 		static_cast<void>(protocol);
-		typename base_ip_endpoint<AddressType>::resolver::query query(ep.address().to_string(), ep.has_port() ? boost::lexical_cast<std::string>(ep.port()) : default_service, boost::asio::ip::resolver_query_base::numeric_host);
-		
+		typename base_ip_endpoint<AddressType>::resolver::query query(ep.address().to_string(), ep.has_port() ? boost::lexical_cast<std::string>(ep.port()) : default_service, flags | boost::asio::ip::resolver_query_base::numeric_host);
+
 		resolver.async_resolve(query, handler);
-		return;
 	}
 
 	/**

--- a/libs/fscp/include/fscp/server.hpp
+++ b/libs/fscp/include/fscp/server.hpp
@@ -1300,7 +1300,7 @@ namespace fscp
 			void async_send_to(const SharedBuffer& data, const size_t size, const ep_type& target, simple_handler_type handler)
 			{
 				const void_handler_type write_handler = [this, data, size, target, handler] () {
-					m_socket.async_send_to(buffer(data, size), target, 0, [data, handler] (const boost::system::error_code& ec, size_t) {
+					m_socket.async_send_to(buffer(data, size), to_socket_format(target), 0, [data, handler] (const boost::system::error_code& ec, size_t) {
 						handler(ec);
 					});
 				};

--- a/libs/fscp/src/server.cpp
+++ b/libs/fscp/src/server.cpp
@@ -1069,7 +1069,7 @@ namespace fscp
 
 	server::ep_type server::to_socket_format(const server::ep_type& ep)
 	{
-#ifdef WINDOWS
+#if defined(WINDOWS) || defined(MACINTOSH)
 		if (m_socket.local_endpoint().address().is_v6() && ep.address().is_v4())
 		{
 			return server::ep_type(boost::asio::ip::address_v6::v4_mapped(ep.address().to_v4()), ep.port());
@@ -1079,8 +1079,6 @@ namespace fscp
 			return ep;
 		}
 #else
-		static_cast<void>(ep);
-
 		return ep;
 #endif
 	}


### PR DESCRIPTION
This should allow one to contact both ipv4 and ipv6 (provided listen_on is set to an ipv6 address). 

There were two issues one resolving host names as described in #196 and two the ipv4 addresses needed to be masked to ipv6 address on macos (ubuntu seemed to do this implicitly).

The first issue was resolved by specializing the resolve template to handle explicit ip addresses differently to the protocol in the settings.

The second issue was resolved by masking ipv4 addresses if the socket is using the ipv6 protocol. There was already code in the library to do this but it seems that it was left uncalled by some prior commit. Perhaps you know when the app stopped masking the ipv4 addresses when needed? Let me know if that causes some edge cases that I might need to work around.

Fixes #197 