### PR TITLE
Fix for boost versions less than 1.66

### DIFF
--- a/libs/fscp/include/fscp/server.hpp
+++ b/libs/fscp/include/fscp/server.hpp
@@ -288,7 +288,11 @@ namespace fscp
 			 */
 			boost::asio::io_service& get_io_service()
 			{
+#if BOOST_ASIO_VERSION >= 101200 // Boost 1.66+
 				return reinterpret_cast<boost::asio::io_context&>(get_socket().get_executor().context());
+#else
+				return get_socket().get_io_service();
+#endif
 			}
 
 			/**


### PR DESCRIPTION
This should allow it to build on older boosts as in prior to boost 1.66. Hopefully this will fix the travis linux build. It is just an `#if` around the critical change in your d16490d commit. I believe the change is in required for pre-boost 1.66 given the change log https://www.boost.org/doc/libs/1_66_0/doc/html/boost_asio/net_ts.html.