### PR TITLE
Fix missing /dev/net/tap

### DIFF
--- a/libs/asiotap/src/posix/posix_tap_adapter.cpp
+++ b/libs/asiotap/src/posix/posix_tap_adapter.cpp
@@ -238,7 +238,7 @@ namespace asiotap
 		m_existing_tap = !_name.empty();
 
 #if defined(LINUX)
-		const std::string dev_name = (layer() == tap_adapter_layer::ethernet) ? "/dev/net/tap" : "/dev/net/tun";
+		const std::string dev_name = "/dev/net/tun";
 
 		if (::access(dev_name.c_str(), F_OK) == -1)
 		{


### PR DESCRIPTION
Always use /dev/net/tun, independent of mode TUN or TAP. This will fix the issue #218.
A node name /dev/net/tap does not exist in default Linux kernel, see https://www.kernel.org/doc/html/v4.15/admin-guide/devices.html
"200 = /dev/net/tun      TAP/TUN network device"

Also not exist, if the /dev/ was build with udev, or pre configured from ditribution.