### PR TITLE
Not terminate, if SIOCSIFTXQLEN fail

### DIFF
--- a/libs/asiotap/src/posix/posix_tap_adapter.cpp
+++ b/libs/asiotap/src/posix/posix_tap_adapter.cpp
@@ -318,7 +318,7 @@ namespace asiotap
 			{
 				ec = boost::system::error_code(errno, boost::system::system_category());
 
-				return;
+				/* Whithout return, because 100 is default and would work to. */
 			}
 
 			// Reset the structure for the next call.


### PR DESCRIPTION
Do not terminate freelan, if SIOCSIFTXQLEN can not set.
100 is the default value. So, it is no problem, if this can not set.
This fix the issue #216.