### PR TITLE
config: IPv6 prefix /8 is not a good example

### DIFF
--- a/apps/freelan/config/freelan.cfg
+++ b/apps/freelan/config/freelan.cfg
@@ -479,7 +479,7 @@ ipv4_dhcp=false
 #
 # Commenting out, will result in no IPv6 networking. You cannot supply a blank value.
 #
-ipv6_address_prefix_length=2aa1::1/8
+ipv6_address_prefix_length=2aa1::1/64
 
 # The remote IPv4 address for tun interfaces.
 #


### PR DESCRIPTION
If some use the example "ipv6_address_prefix_length=2aa1::1/8", then have a good chance to kick of self. 8 bit is a very big network.
Prefix /64 is a better choice for an eample.